### PR TITLE
Add support for "caret line"-styling (scintilla only)

### DIFF
--- a/maxide.bmx
+++ b/maxide.bmx
@@ -7838,7 +7838,6 @@ Type TCodePlay
 				End Select
 
 			Case EVENT_WINDOWACCEPT, EVENT_APPOPENFILE
-				print EventText()
 				OpenSource EventText()
 
 			Case EVENT_APPTERMINATE


### PR DESCRIPTION
Setup dialogue does not look sweet now but adding a new line would increase settings window even more - and it should require an complete overhaul (which means efforts better put elsewhere).

__Requires__ the PR of maxgui adding support for line caret styling.