### PR TITLE
Change block indend shortcut from arbitrary to common

### DIFF
--- a/maxide.bmx
+++ b/maxide.bmx
@@ -6960,8 +6960,8 @@ Type TCodePlay
 		CreateMenu "",0,edit
 		CreateMenu "{{menu_edit_selectall}}",MENUSELECTALL,edit,KEY_A,MENUMOD
 		CreateMenu "",0,edit
-		CreateMenu "{{menu_edit_blockindent}}",MENUINDENT,edit,KEY_CLOSEBRACKET,MENUMOD
-		CreateMenu "{{menu_edit_blockoutdent}}",MENUOUTDENT,edit,KEY_OPENBRACKET,MENUMOD
+		CreateMenu "{{menu_edit_blockindent}}",MENUINDENT,edit,KEY_TAB
+		CreateMenu "{{menu_edit_blockoutdent}}",MENUOUTDENT,edit,KEY_TAB,MODIFIER_SHIFT
 		CreateMenu "",0,edit
 		CreateMenu "{{menu_edit_find}}",MENUFIND,edit,KEY_F,MENUMOD
 ?MacOS


### PR DESCRIPTION
MaxIDE defines "TAB" and "Shift TAB" for block indent/outdent (this was added by @woollybah and was not there in very earlier versions). Same shortcuts are used when the scintilla textarea is used.

Until this commit the MaxIDE menu defines "Ctrl [" and "Ctrl ]" as shortcut for this action.

References #41