### PR TITLE
Remove support for "projects" and "svn"

### DIFF
--- a/default.language.ini
+++ b/default.language.ini
@@ -148,37 +148,6 @@ caretline_visible                            = "Show Caret Line"
 ; Line Number Style Control
 linenumberstyle_enabled                      = "Show"
 
-; Project Manager
-projman_window_title                         = "Project Manager"
-projman_btn_addproj                          = "Add Project"
-projman_btn_delproj                          = "Remove Project"
-projman_btn_moveup                           = "Move Up"
-projman_btn_movedn                           = "Move Down"
-projman_btn_properties                       = "Properties"
-
-; Project Requester
-project_window_title                         = "Project Properties"
-project_group_details                        = "Project Details"
-project_label_name                           = "Name"
-project_defaultname                          = "New Project"
-project_label_path                           = "Path"
-project_group_svn                            = "Subversion Control"
-project_label_url                            = "URL"
-project_label_username                       = "Username"
-project_label_password                       = "Password"
-project_btn_checkout                         = "Check Out Project"
-project_btn_update                           = "Update Project"
-project_btn_commit                           = "Commit Project"
-project_requestfolder_title                  = "Select the project folder"
-
-; Syncmods Requester
-syncmods_window_title                        = "Synchronize Modules"
-syncmods_label_username                      = "Username"
-syncmods_label_password                      = "Password"
-syncmods_label_proxyserver                   = "Proxy Server"
-syncmods_process_label                       = "Synchronize Modules"
-syncmods_btn_sync                            = "Sync"
-
 ; Search Requester
 search_window_title                          = "Find In Files"
 search_label_find                            = "Find"
@@ -205,14 +174,6 @@ request_openfile                             = "Open File"
 request_saveas_title                         = "Save As"
 request_importbb_title                       = "Import .bb file"
 request_savechanges                          = "Save changes to %1?"
-notify_demo_featureunavailable               = "This feature is unavailable in the demo version of BlitzMax."
-
-; SVN Messages
-svn_notification_nodehostnotfound            = "Node host not found."
-svn_notification_nodeprojectnotfound         = "Node project not found."
-svn_msg_updating                             = "Updating %1"
-svn_msg_committing                           = "Committing %1"
-svn_msg_checkingout                          = "Checking out %1 to %2"
 
 ; Output Messages
 output_error_compileerror                    = "Compile Error\n\n%1"
@@ -351,13 +312,3 @@ popup_output_cut                             = "Cut"
 popup_output_copy                            = "Copy"
 popup_output_paste                           = "Paste"
 popup_output_stop                            = "Stop"
-
-popup_nav_proj                               = "Proj"
-popup_nav_proj_refresh                       = "Refresh"
-popup_nav_proj_clean                         = "Clean"
-popup_nav_proj_findinfiles                   = "Find in Files"
-popup_nav_proj_explore                       = "Explore"
-popup_nav_proj_shell                         = "Shell"
-popup_nav_proj_svnupdate                     = "Update Version"
-popup_nav_proj_svncommit                     = "Commit Version"
-popup_nav_proj_properties                    = "Properties"


### PR DESCRIPTION
with Projects you were able to update/fetch via SVN - and to directly call "find in files" for the specified directory. There was no further functionality (like auto-locking buildfiles, opening all files in the dir ... or so).